### PR TITLE
feat(RealitioProxy): update contract for V2

### DIFF
--- a/.vscode/contract-decorators.code-snippets
+++ b/.vscode/contract-decorators.code-snippets
@@ -1,0 +1,118 @@
+{
+	// Place your kleros-v2 workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+	// description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+	// is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+	// used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+	// $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+	// Placeholders with the same ids are connected.
+	// Example:
+	// "Print to console": {
+	// 	"scope": "javascript,typescript",
+	// 	"prefix": "log",
+	// 	"body": [
+	// 		"console.log('$1');",
+	// 		"$2"
+	// 	],
+	// 	"description": "Log output to console"
+	// }
+	"Decorator for the Enums / Structs section": {
+		"scope": "solidity",
+		"prefix": "/struct",
+		"body": [
+			"// ************************************* //",
+			"// *         Enums / Structs           * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Storage section": {
+		"scope": "solidity",
+		"prefix": "/stor",
+		"body": [
+			"// ************************************* //",
+			"// *             Storage               * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Events section": {
+		"scope": "solidity",
+		"prefix": "/event",
+		"body": [
+			"// ************************************* //",
+			"// *              Events               * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Function Modifiers section": {
+		"scope": "solidity",
+		"prefix": "/modif",
+		"body": [
+			"// ************************************* //",
+			"// *        Function Modifiers         * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Constructor section": {
+		"scope": "solidity",
+		"prefix": "/constr",
+		"body": [
+			"// ************************************* //",
+			"// *            Constructor            * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Initializer section": {
+		"scope": "solidity",
+		"prefix": "/init",
+		"body": [
+			"// ************************************* //",
+			"// *            Initializer            * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Governance section": {
+		"scope": "solidity",
+		"prefix": "/gov",
+		"body": [
+			"// ************************************* //",
+			"// *             Governance            * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the State Modifiers section": {
+		"scope": "solidity",
+		"prefix": "/state",
+		"body": [
+			"// ************************************* //",
+			"// *         State Modifiers           * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Public Views section": {
+		"scope": "solidity",
+		"prefix": "/view",
+		"body": [
+			"// ************************************* //",
+			"// *           Public Views            * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+	"Decorator for the Internal section": {
+		"scope": "solidity",
+		"prefix": "/intern",
+		"body": [
+			"// ************************************* //",
+			"// *            Internal               * //",
+			"// ************************************* //",
+			"$0"
+		]
+	},
+}

--- a/contracts/deploy/00-reality-v2.ts
+++ b/contracts/deploy/00-reality-v2.ts
@@ -2,34 +2,36 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HomeChains, isSkipped } from "./utils";
 
-const disputeTemplate = `{
-  "$schema": "../NewDisputeTemplate.schema.json",
-  "title": "Let's do this",
-  "description": "We want to do this: %s",
-  "question": "Does it comply with the policy?",
-  "answers": [
-    {
-      "title": "Yes",
-      "description": "Select this if you agree that it must be done."
-    },
-    {
-      "title": "No",
-      "description": "Select this if you do not agree that it must be done."
-    }
-  ],
-  "policyURI": "/ipfs/Qmdvk...rSD6cE/policy.pdf",
-  "frontendUrl": "https://kleros-v2.netlify.app/#/cases/%s/overview",
-  "arbitratorChainID": "421614",
-  "arbitratorAddress": "0xD08Ab99480d02bf9C092828043f611BcDFEA917b",
-  "category": "Others",
-  "specification": "KIP001",
-  "lang": "en_US"
-}
-`;
+const disputeTemplateFn = (chainId: number, arbitratorAddress: string) => `{
+    "title": "A reality.eth question",
+    "description": "A reality.eth question has been raised to arbitration.",
+    "question": "{{ question }}",
+    "type": "{{ type }}",
+    "answers": [
+      {
+        "title": "Answered Too Soon",
+        "description": "Answered Too Soon.",
+      },
+      {{# answers }}
+      {
+          "title": "{{ title }}",
+          "description": "{{ description }}",
+      }{{^ last }},{{/ last }}
+      {{/ answers }}
+    ],
+    "policyURI": "/ipfs/QmZ5XaV2RVgBADq5qMpbuEwgCuPZdRgCeu8rhGtJWLV6yz",
+    "frontendUrl": "https://reality.eth.limo/app/#!/question/{{ realityAddress }}-{{ questionId }}",
+    "arbitratorChainID": "${chainId}",
+    "arbitratorAddress": "${arbitratorAddress}",
+    "category": "Oracle",
+    "lang": "en_US",
+    "specification": "KIP99",
+    "version": "1.0"
+}`;
 
 // General court, 3 jurors
 const extraData =
-    "0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003";
+  "0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003";
 
 const deploy: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { deployments, getNamedAccounts, getChainId } = hre;
@@ -42,14 +44,16 @@ const deploy: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   const klerosCore = await deployments.get("KlerosCore");
   const disputeTemplateRegistry = await deployments.get("DisputeTemplateRegistry");
-  
+  const disputeTemplate = disputeTemplateFn(chainId, klerosCore.address);
+  const disputeTemplateMappings = "TODO";
+
   await deploy("RealityV2", {
     from: deployer,
     args: [
       klerosCore.address,
       extraData,
       disputeTemplate,
-      "disputeTemplateMapping: TODO",
+      disputeTemplateMappings,
       disputeTemplateRegistry.address,
       600, // feeTimeout: 10 minutes
     ],

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -17,7 +17,7 @@ dotenv.config();
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.18",
+    version: "0.8.24",
     settings: {
       optimizer: {
         enabled: true,

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -85,6 +85,7 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "@kleros/kleros-v2-contracts": "^0.3.2"
+    "@kleros/kleros-v2-contracts": "^0.7.0",
+    "@openzeppelin/contracts": "^5.2.0"
   }
 }

--- a/contracts/src/RealityV2.sol
+++ b/contracts/src/RealityV2.sol
@@ -1,142 +1,149 @@
 // SPDX-License-Identifier: MIT
 
-/// @authors: []
-/// @reviewers: []
-/// @auditors: []
-/// @bounties: []
+/**
+ *  @authors: [@unknownunknown1]
+ *  @reviewers: []
+ *  @auditors: []
+ *  @bounties: []
+ *  @deployments: []
+ */
 
 pragma solidity 0.8.18;
 
 import {IArbitrableV2, IArbitratorV2} from "@kleros/kleros-v2-contracts/arbitration/interfaces/IArbitrableV2.sol";
 import "@kleros/kleros-v2-contracts/arbitration/interfaces/IDisputeTemplateRegistry.sol";
+import "./interfaces/IRealitio.sol";
+import "./interfaces/IRealitioArbitrator.sol";
 
-/// @title TODO
-/// @dev TODO
-contract RealityV2 is IArbitrableV2 {
-    // ************************************* //
-    // *         Enums / Structs           * //
-    // ************************************* //
+/// @title RealitioProxyV2
+/// @dev Realitio proxy contract compatible with V2.
+contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
+    uint256 public constant REFUSE_TO_ARBITRATE_REALITIO = type(uint256).max; // Constant that represents "Refuse to rule" in realitio format.
 
-    struct Dispute {
-        bool isRuled; // Whether the dispute has been ruled or not.
-        uint256 ruling; // Ruling given by the arbitrator.
+    IRealitio public immutable override realitio; // Actual implementation of Realitio.
+    IArbitratorV2 public immutable arbitrator; // The Kleros arbitrator.
+    bytes public arbitratorExtraData; // Required for Kleros arbitrator. First 64 bytes contain subcourtID and the second 64 bytes contain number of votes in the jury.
+    string public override metadata; // Metadata for Realitio. See IRealitioArbitrator.
+
+    IDisputeTemplateRegistry public immutable templateRegistry; // The dispute template registry.
+    uint256 public templateId; // Dispute template identifier.
+
+    uint256 private constant NUMBER_OF_RULING_OPTIONS = type(uint256).max; // The amount of non 0 choices the arbitrator can give.
+
+    enum Status {
+        None, // The question hasn't been requested arbitration yet.
+        Disputed, // The question has been requested arbitration.
+        Ruled, // The question has been ruled by arbitrator.
+        Reported // The answer of the question has been reported to Realitio.
     }
 
-    // ************************************* //
-    // *             Storage               * //
-    // ************************************* //
-
-    address public immutable governor;
-    IArbitratorV2 public arbitrator; // Address of the arbitrator contract.
-    bytes public arbitratorExtraData; // Extra data to set up the arbitration.
-    IDisputeTemplateRegistry public templateRegistry; // The dispute template registry.
-    uint256 public templateId; // The current dispute template identifier.
-    mapping(uint256 => uint256) public externalIDtoLocalID; // Maps external (arbitrator side) dispute IDs to local dispute IDs.
-    Dispute[] public disputes; // Stores the disputes' info. disputes[disputeID].
-
-    // ************************************* //
-    // *              Events               * //
-    // ************************************* //
-
-    // TODO
-
-    // ************************************* //
-    // *        Function Modifiers         * //
-    // ************************************* //
-
-    modifier onlyByGovernor() {
-        if (governor != msg.sender) revert GovernorOnly();
-        _;
+    // To track internal dispute state in this contract.
+    struct ArbitrationRequest {
+        Status status; // The current status of the question.
+        address requester; // The address that requested the arbitration.
+        uint256 disputeID; // The ID of the dispute raised in the arbitrator contract.
+        uint256 ruling; // The ruling given by the arbitrator.
     }
 
-    // ************************************* //
-    // *            Constructor            * //
-    // ************************************* //
+    mapping(uint256 => ArbitrationRequest) public arbitrationRequests; // Maps a question identifier in uint256 to its arbitration details. Example: arbitrationRequests[uint256(questionID)]
+    mapping(uint256 => uint256) public externalIDtoLocalID; // Maps arbitrator dispute identifiers to local identifiers. We use question ids casted to uint256 as local identifier.
 
-    /// @dev Constructor.
-    /// @param _arbitrator The arbitrator of the contract.
-    /// @param _arbitratorExtraData Extra data for the arbitrator.
+    /// @dev Constructor
+    /// @param _realitio The address of the Realitio contract.
+    /// @param _metadata The metadata required for RealitioArbitrator.
+    /// @param _arbitrator The address of the ERC792 arbitrator.
+    /// @param _arbitratorExtraData The extra data used to raise a dispute in the ERC792 arbitrator.
+    /// @param _templateRegistry The dispute template registry.
     /// @param _templateData The dispute template data.
     /// @param _templateDataMappings The dispute template data mappings.
-    /// @param _templateRegistry The dispute template registry.
     constructor(
+        IRealitio _realitio,
+        string memory _metadata,
         IArbitratorV2 _arbitrator,
         bytes memory _arbitratorExtraData,
-        string memory _templateData,
-        string memory _templateDataMappings,
-        IDisputeTemplateRegistry _templateRegistry
-    ) {
-        governor = msg.sender;
-        arbitrator = _arbitrator;
-        arbitratorExtraData = _arbitratorExtraData;
-        templateRegistry = _templateRegistry;
-
-        templateId = templateRegistry.setDisputeTemplate("", _templateData, _templateDataMappings);
-    }
-
-    // ************************************* //
-    // *             Governance            * //
-    // ************************************* //
-
-    function changeArbitrator(IArbitratorV2 _arbitrator) external onlyByGovernor {
-        arbitrator = _arbitrator;
-    }
-
-    function changeArbitratorExtraData(bytes calldata _arbitratorExtraData) external onlyByGovernor {
-        arbitratorExtraData = _arbitratorExtraData;
-    }
-
-    function changeTemplateRegistry(IDisputeTemplateRegistry _templateRegistry) external onlyByGovernor {
-        templateRegistry = _templateRegistry;
-    }
-
-    function changeDisputeTemplate(
+        IDisputeTemplateRegistry _templateRegistry,
         string memory _templateData,
         string memory _templateDataMappings
-    ) external onlyByGovernor {
+    ) {
+        realitio = _realitio;
+        metadata = _metadata;
+        arbitrator = _arbitrator;
+        arbitratorExtraData = _arbitratorExtraData;
+        templateRegistry = _templateRegistry;
         templateId = templateRegistry.setDisputeTemplate("", _templateData, _templateDataMappings);
     }
 
-    // ************************************* //
-    // *         State Modifiers           * //
-    // ************************************* //
+    /// @dev Request arbitration from Kleros for given _questionID.
+    /// @param _questionID The question identifier in Realitio contract.
+    /// @param _maxPrevious If specified, reverts if a bond higher than this was submitted after you sent your transaction.
+    /// @return disputeID ID of the resulting dispute in arbitrator.
+    function requestArbitration(bytes32 _questionID, uint256 _maxPrevious) external payable returns (uint256 disputeID) {
+        ArbitrationRequest storage arbitrationRequest = arbitrationRequests[uint256(_questionID)];
+        if(arbitrationRequest.status != Status.None) revert ArbitrationAlreadyRequested();
 
-    /// @dev Calls createDispute function of the specified arbitrator to create a dispute.
-    /// Note that we don’t need to check that msg.value is enough to pay arbitration fees as it’s the responsibility of the arbitrator contract.
-    /// @return disputeID Dispute id (on arbitrator side) of the dispute created.
-    function createDispute() external payable returns (uint256 disputeID) {
-        uint256 numberOfRulingOptions = 2;
-        uint256 localDisputeID = disputes.length;
-        disputes.push(Dispute({isRuled: false, ruling: 0}));
+        // Notify Kleros
+        disputeID = arbitrator.createDispute{value: msg.value}(NUMBER_OF_RULING_OPTIONS, arbitratorExtraData); /* If msg.value is greater than intended number of votes (specified in arbitratorExtraData),
+        Kleros will automatically spend excess for additional votes. */
+        externalIDtoLocalID[disputeID] = uint256(_questionID);
 
-        disputeID = arbitrator.createDispute{value: msg.value}(numberOfRulingOptions, arbitratorExtraData);
-        externalIDtoLocalID[disputeID] = localDisputeID;
+        // Update internal state
+        arbitrationRequest.requester = msg.sender;
+        arbitrationRequest.status = Status.Disputed;
+        arbitrationRequest.disputeID = disputeID;
 
-        uint256 externalDisputeID = uint256(keccak256(abi.encodePacked("Hello World!")));
-        emit DisputeRequest(arbitrator, disputeID, externalDisputeID, templateId, "");
+        // Notify Realitio
+        realitio.notifyOfArbitrationRequest(_questionID, msg.sender, _maxPrevious);
+        emit DisputeRequest(arbitrator, disputeID, uint256(_questionID), templateId, "");
     }
 
-    /// @dev To be called by the arbitrator of the dispute, to declare the winning ruling.
-    /// @param _externalDisputeID ID of the dispute in arbitrator contract.
-    /// @param _ruling The ruling choice of the arbitration.
-    function rule(uint256 _externalDisputeID, uint256 _ruling) external override {
-        if (msg.sender != address(arbitrator)) revert ArbitratorOnly();
+    /// @dev Receives ruling from Kleros and enforces it.
+    /// @param _disputeID ID of Kleros dispute.
+    /// @param _ruling Ruling that is given by Kleros. This needs to be converted to Realitio answer before reporting the answer by shifting by 1.
+    function rule(uint256 _disputeID, uint256 _ruling) public override {
+        if(IArbitratorV2(msg.sender) != arbitrator) revert ArbitratorOnly();
 
-        uint256 localDisputeID = externalIDtoLocalID[_externalDisputeID];
-        Dispute storage dispute = disputes[localDisputeID];
-        if (dispute.isRuled) revert DisputeAlreadyResolved();
+        uint256 questionID = externalIDtoLocalID[_disputeID];
+        ArbitrationRequest storage arbitrationRequest = arbitrationRequests[questionID];
 
-        dispute.isRuled = true;
-        dispute.ruling = _ruling;
+        if(arbitrationRequest.status != Status.Disputed) revert StatusNotDisputed();
 
-        emit Ruling(IArbitratorV2(msg.sender), _externalDisputeID, _ruling);
+        arbitrationRequest.ruling = _ruling;
+        arbitrationRequest.status = Status.Ruled;
+
+        emit Ruling(IArbitratorV2(msg.sender), _disputeID, _ruling);
     }
 
-    // ************************************* //
-    // *              Errors               * //
-    // ************************************* //
+    /// @dev Reports the answer to a specified question from Kleros arbitrator to the Realitio contract.
+    /// This can be called by anyone, after the dispute gets a ruling from Kleros.
+    /// We can't directly call `assignWinnerAndSubmitAnswerByArbitrator` inside `rule` because last answerer is not stored on chain.
+    /// @param _questionID The ID of Realitio question.
+    /// @param _lastHistoryHash The history hash given with the last answer to the question in the Realitio contract.
+    /// @param _lastAnswerOrCommitmentID The last answer given, or its commitment ID if it was a commitment, to the question in the Realitio contract, in bytes32.
+    /// @param _lastAnswerer The last answerer to the question in the Realitio contract.
+    function reportAnswer(
+        bytes32 _questionID,
+        bytes32 _lastHistoryHash,
+        bytes32 _lastAnswerOrCommitmentID,
+        address _lastAnswerer
+    ) external {
+        ArbitrationRequest storage arbitrationRequest = arbitrationRequests[uint256(_questionID)];
+        if(arbitrationRequest.status != Status.Ruled) revert StatusNotRuled();
 
-    error GovernorOnly();
+        arbitrationRequest.status = Status.Reported;
+        // Realitio ruling is shifted by 1 compared to Kleros.
+        uint256 realitioRuling = arbitrationRequest.ruling != 0 ? arbitrationRequest.ruling - 1 : REFUSE_TO_ARBITRATE_REALITIO;
+
+        realitio.assignWinnerAndSubmitAnswerByArbitrator(_questionID, bytes32(realitioRuling), arbitrationRequest.requester, _lastHistoryHash, _lastAnswerOrCommitmentID, _lastAnswerer);
+    }
+
+    /// @dev Returns arbitration fee by calling arbitrationCost function in the arbitrator contract.
+    /// @return fee Arbitration fee that needs to be paid.
+    function getDisputeFee(bytes32) external view override returns (uint256 fee) {
+        return arbitrator.arbitrationCost(arbitratorExtraData);
+    }
+
+    error StatusNotDisputed();
+    error StatusNotRuled();
+    error ArbitrationAlreadyRequested();
     error ArbitratorOnly();
-    error DisputeAlreadyResolved();
 }

--- a/contracts/src/RealityV2.sol
+++ b/contracts/src/RealityV2.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import {IArbitrableV2, IArbitratorV2} from "@kleros/kleros-v2-contracts/arbitration/interfaces/IArbitrableV2.sol";
 import {EvidenceModule} from "@kleros/kleros-v2-contracts/arbitration/evidence/EvidenceModule.sol";
@@ -58,8 +58,8 @@ contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
     address public governor; // The address that can make changes to the parameters of the contract.
     IDisputeTemplateRegistry public templateRegistry; // The dispute template registry.
     uint256 public templateId; // Dispute template identifier.
-    mapping(uint256 => ArbitrationRequest) public arbitrationRequests; // Maps a question identifier in uint256 to its arbitration details. Example: arbitrationRequests[uint256(questionID)]
-    mapping(address => mapping(uint256 => uint256)) public arbitratorDisputeIDToQuestionID; // Maps a dispute ID to the ID of the question (converted into uint) with the disputed request in the form arbitratorDisputeIDToQuestionID[arbitrator][disputeID].
+    mapping(uint256 questionID => ArbitrationRequest) public arbitrationRequests; // Maps a question identifier in uint256 to its arbitration details. Example: arbitrationRequests[uint256(questionID)]
+    mapping(address arbitrator => mapping(uint256 disputeID => uint256 questionID)) public arbitratorDisputeIDToQuestionID; // Maps a dispute ID to the ID of the question (converted into uint) with the disputed request in the form arbitratorDisputeIDToQuestionID[arbitrator][disputeID].
     ArbitrationParams[] public arbitrationParamsChanges;
 
     // ************************************* //

--- a/contracts/src/RealityV2.sol
+++ b/contracts/src/RealityV2.sol
@@ -11,6 +11,7 @@
 pragma solidity 0.8.18;
 
 import {IArbitrableV2, IArbitratorV2} from "@kleros/kleros-v2-contracts/arbitration/interfaces/IArbitrableV2.sol";
+import {EvidenceModule} from "@kleros/kleros-v2-contracts/arbitration/evidence/EvidenceModule.sol";
 import "@kleros/kleros-v2-contracts/arbitration/interfaces/IDisputeTemplateRegistry.sol";
 import "./interfaces/IRealitio.sol";
 import "./interfaces/IRealitioArbitrator.sol";
@@ -21,11 +22,10 @@ contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
     uint256 public constant REFUSE_TO_ARBITRATE_REALITIO = type(uint256).max; // Constant that represents "Refuse to rule" in realitio format.
 
     IRealitio public immutable override realitio; // Actual implementation of Realitio.
-    IArbitratorV2 public immutable arbitrator; // The Kleros arbitrator.
-    bytes public arbitratorExtraData; // Required for Kleros arbitrator. First 64 bytes contain subcourtID and the second 64 bytes contain number of votes in the jury.
     string public override metadata; // Metadata for Realitio. See IRealitioArbitrator.
 
-    IDisputeTemplateRegistry public immutable templateRegistry; // The dispute template registry.
+    address public governor; // The address that can make changes to the parameters of the contract.
+    IDisputeTemplateRegistry public templateRegistry; // The dispute template registry.
     uint256 public templateId; // Dispute template identifier.
 
     uint256 private constant NUMBER_OF_RULING_OPTIONS = type(uint256).max; // The amount of non 0 choices the arbitrator can give.
@@ -43,33 +43,102 @@ contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
         address requester; // The address that requested the arbitration.
         uint256 disputeID; // The ID of the dispute raised in the arbitrator contract.
         uint256 ruling; // The ruling given by the arbitrator.
+        uint256 arbitrationParamsIndex; // The index for the arbitration params for the request.
+        // TODO: should template registry be a part of the struct in case it's changed?
+        IDisputeTemplateRegistry templateRegistry; // Address of template registry used for the request.
+    }
+
+    struct ArbitrationParams {
+        IArbitratorV2 arbitrator; // The arbitrator trusted to solve disputes for this request.
+        bytes arbitratorExtraData; // The extra data for the trusted arbitrator of this request.
+        EvidenceModule evidenceModule; // The evidence module for the arbitrator.
     }
 
     mapping(uint256 => ArbitrationRequest) public arbitrationRequests; // Maps a question identifier in uint256 to its arbitration details. Example: arbitrationRequests[uint256(questionID)]
-    mapping(uint256 => uint256) public externalIDtoLocalID; // Maps arbitrator dispute identifiers to local identifiers. We use question ids casted to uint256 as local identifier.
+    mapping(address => mapping(uint256 => uint256)) public arbitratorDisputeIDToQuestionID; // Maps a dispute ID to the ID of the question (converted into uint) with the disputed request in the form arbitratorDisputeIDToQuestionID[arbitrator][disputeID].
+    ArbitrationParams[] public arbitrationParamsChanges;
+
+     modifier onlyGovernor() {
+        if (governor != msg.sender) revert GovernorOnly();
+        _;
+    }
 
     /// @dev Constructor
+    /// @param _governor The trusted governor of this contract.
     /// @param _realitio The address of the Realitio contract.
     /// @param _metadata The metadata required for RealitioArbitrator.
     /// @param _arbitrator The address of the ERC792 arbitrator.
     /// @param _arbitratorExtraData The extra data used to raise a dispute in the ERC792 arbitrator.
+    /// @param _evidenceModule The evidence contract for the arbitrator.
     /// @param _templateRegistry The dispute template registry.
     /// @param _templateData The dispute template data.
     /// @param _templateDataMappings The dispute template data mappings.
     constructor(
+        address _governor,
         IRealitio _realitio,
         string memory _metadata,
         IArbitratorV2 _arbitrator,
         bytes memory _arbitratorExtraData,
+        EvidenceModule _evidenceModule,
         IDisputeTemplateRegistry _templateRegistry,
         string memory _templateData,
         string memory _templateDataMappings
     ) {
+        governor = _governor;
         realitio = _realitio;
         metadata = _metadata;
-        arbitrator = _arbitrator;
-        arbitratorExtraData = _arbitratorExtraData;
         templateRegistry = _templateRegistry;
+        templateId = templateRegistry.setDisputeTemplate("", _templateData, _templateDataMappings);
+        arbitrationParamsChanges.push(
+            ArbitrationParams({
+                arbitrator: _arbitrator,
+                arbitratorExtraData: _arbitratorExtraData,
+                evidenceModule: _evidenceModule
+            })
+        );
+    }
+
+    /// @dev Changes the governor of the Reality proxy.
+    /// @param _governor The address of the new governor.
+    function changeGovernor(address _governor) external onlyGovernor {
+        governor = _governor;
+    }
+
+    /// @notice Changes the params related to arbitration.
+    /// @param _arbitrator Arbitrator to resolve potential disputes. The arbitrator is trusted to support appeal periods and not reenter.
+    /// @param _arbitratorExtraData Extra data for the trusted arbitrator contract.
+    /// @param _evidenceModule The evidence module for the arbitrator.
+    function changeArbitrationParams(
+        IArbitratorV2 _arbitrator,
+        bytes calldata _arbitratorExtraData,
+        EvidenceModule _evidenceModule
+    ) external onlyGovernor {
+        arbitrationParamsChanges.push(
+            ArbitrationParams({
+                arbitrator: _arbitrator,
+                arbitratorExtraData: _arbitratorExtraData,
+                evidenceModule: _evidenceModule
+            })
+        );
+    }
+
+    /// @dev Changes the address of Template Registry contract.
+    /// @param _templateRegistry The new template registry.
+    /// @param _templateData The new template data for template registry.
+    /// @param _templateDataMappings The new data mappings json.
+    function changeTemplateRegistry(
+        IDisputeTemplateRegistry _templateRegistry,
+        string memory _templateData,
+        string memory _templateDataMappings)
+     external onlyGovernor {
+        templateRegistry = _templateRegistry;
+        templateId = templateRegistry.setDisputeTemplate("", _templateData, _templateDataMappings);
+    }
+
+    /// @dev Changes the dispute template.
+    /// @param _templateData The new template data for requests.
+    /// @param _templateDataMappings The new data mappings json.
+    function changeDisputeTemplate(string memory _templateData, string memory _templateDataMappings) external onlyGovernor {
         templateId = templateRegistry.setDisputeTemplate("", _templateData, _templateDataMappings);
     }
 
@@ -80,16 +149,21 @@ contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
     function requestArbitration(bytes32 _questionID, uint256 _maxPrevious) external payable returns (uint256 disputeID) {
         ArbitrationRequest storage arbitrationRequest = arbitrationRequests[uint256(_questionID)];
         if(arbitrationRequest.status != Status.None) revert ArbitrationAlreadyRequested();
+        uint256 arbitrationParamsIndex = arbitrationParamsChanges.length - 1;
+        IArbitratorV2 arbitrator = arbitrationParamsChanges[arbitrationParamsIndex].arbitrator;
+        bytes storage arbitratorExtraData = arbitrationParamsChanges[arbitrationParamsIndex].arbitratorExtraData;
 
         // Notify Kleros
         disputeID = arbitrator.createDispute{value: msg.value}(NUMBER_OF_RULING_OPTIONS, arbitratorExtraData); /* If msg.value is greater than intended number of votes (specified in arbitratorExtraData),
         Kleros will automatically spend excess for additional votes. */
-        externalIDtoLocalID[disputeID] = uint256(_questionID);
+        arbitratorDisputeIDToQuestionID[address(arbitrator)][disputeID] = uint256(_questionID);
 
         // Update internal state
         arbitrationRequest.requester = msg.sender;
         arbitrationRequest.status = Status.Disputed;
         arbitrationRequest.disputeID = disputeID;
+        arbitrationRequest.arbitrationParamsIndex = arbitrationParamsIndex;
+        arbitrationRequest.templateRegistry = templateRegistry;
 
         // Notify Realitio
         realitio.notifyOfArbitrationRequest(_questionID, msg.sender, _maxPrevious);
@@ -100,11 +174,11 @@ contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
     /// @param _disputeID ID of Kleros dispute.
     /// @param _ruling Ruling that is given by Kleros. This needs to be converted to Realitio answer before reporting the answer by shifting by 1.
     function rule(uint256 _disputeID, uint256 _ruling) public override {
-        if(IArbitratorV2(msg.sender) != arbitrator) revert ArbitratorOnly();
-
-        uint256 questionID = externalIDtoLocalID[_disputeID];
+        uint256 questionID = arbitratorDisputeIDToQuestionID[msg.sender][_disputeID];
         ArbitrationRequest storage arbitrationRequest = arbitrationRequests[questionID];
-
+        IArbitratorV2 arbitrator = arbitrationParamsChanges[arbitrationRequest.arbitrationParamsIndex].arbitrator;
+        
+        if(IArbitratorV2(msg.sender) != arbitrator) revert ArbitratorOnly();
         if(arbitrationRequest.status != Status.Disputed) revert StatusNotDisputed();
 
         arbitrationRequest.ruling = _ruling;
@@ -139,6 +213,9 @@ contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
     /// @dev Returns arbitration fee by calling arbitrationCost function in the arbitrator contract.
     /// @return fee Arbitration fee that needs to be paid.
     function getDisputeFee(bytes32) external view override returns (uint256 fee) {
+        uint256 arbitrationParamsIndex = arbitrationParamsChanges.length - 1;
+        IArbitratorV2 arbitrator = arbitrationParamsChanges[arbitrationParamsIndex].arbitrator;
+        bytes storage arbitratorExtraData = arbitrationParamsChanges[arbitrationParamsIndex].arbitratorExtraData;
         return arbitrator.arbitrationCost(arbitratorExtraData);
     }
 
@@ -146,4 +223,5 @@ contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
     error StatusNotRuled();
     error ArbitrationAlreadyRequested();
     error ArbitratorOnly();
+    error GovernorOnly();
 }

--- a/contracts/src/RealityV2.sol
+++ b/contracts/src/RealityV2.sol
@@ -37,8 +37,6 @@ contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
         uint256 disputeID; // The ID of the dispute raised in the arbitrator contract.
         uint256 ruling; // The ruling given by the arbitrator.
         uint256 arbitrationParamsIndex; // The index for the arbitration params for the request.
-        // TODO: should template registry be a part of the struct in case it's changed?
-        IDisputeTemplateRegistry templateRegistry; // Address of template registry used for the request.
     }
 
     struct ArbitrationParams {
@@ -192,7 +190,6 @@ contract RealitioProxyV2 is IRealitioArbitrator, IArbitrableV2 {
         arbitrationRequest.status = Status.Disputed;
         arbitrationRequest.disputeID = disputeID;
         arbitrationRequest.arbitrationParamsIndex = arbitrationParamsIndex;
-        arbitrationRequest.templateRegistry = templateRegistry;
 
         // Notify Realitio
         realitio.notifyOfArbitrationRequest(_questionID, msg.sender, _maxPrevious);

--- a/contracts/src/interfaces/IRealitio.sol
+++ b/contracts/src/interfaces/IRealitio.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ *  @authors: [@ferittuncer]
+ *  @reviewers: [@hbarcelos]
+ *  @auditors: []
+ *  @bounties: []
+ *  @deployments: []
+ */
+
+pragma solidity 0.8.18;
+
+/**
+ *  @title IRealitio
+ *  @dev Required subset of https://github.com/realitio/realitio-contracts/blob/master/truffle/contracts/IRealitio.sol to implement a Realitio arbitrator.
+ */
+interface IRealitio {
+    /// @notice Notify the contract that the arbitrator has been paid for a question, freezing it pending their decision.
+    /// @dev The arbitrator contract is trusted to only call this if they've been paid, and tell us who paid them.
+    /// @param question_id The ID of the question
+    /// @param requester The account that requested arbitration
+    /// @param max_previous If specified, reverts if a bond higher than this was submitted after you sent your transaction.
+    function notifyOfArbitrationRequest(
+        bytes32 question_id,
+        address requester,
+        uint256 max_previous
+    ) external;
+
+    /// @notice Submit the answer for a question, for use by the arbitrator, working out the appropriate winner based on the last answer details.
+    /// @dev Doesn't require (or allow) a bond. Required in v2.1 onwards.
+    /// @param question_id The ID of the question
+    /// @param answer The answer, encoded into bytes32
+    /// @param payee_if_wrong The account to by credited as winner if the last answer given is wrong, usually the account that paid the arbitrator
+    /// @param last_history_hash The history hash before the final one
+    /// @param last_answer_or_commitment_id The last answer given, or the commitment ID if it was a commitment.
+    /// @param last_answerer The address that supplied the last answer
+    function assignWinnerAndSubmitAnswerByArbitrator(
+        bytes32 question_id,
+        bytes32 answer,
+        address payee_if_wrong,
+        bytes32 last_history_hash,
+        bytes32 last_answer_or_commitment_id,
+        address last_answerer
+    ) external;
+}

--- a/contracts/src/interfaces/IRealitio.sol
+++ b/contracts/src/interfaces/IRealitio.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 /**
  *  @title IRealitio

--- a/contracts/src/interfaces/IRealitioArbitrator.sol
+++ b/contracts/src/interfaces/IRealitioArbitrator.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ *  @authors: [@ferittuncer]
+ *  @reviewers: [@hbarcelos]
+ *  @auditors: []
+ *  @bounties: []
+ *  @deployments: []
+ */
+
+pragma solidity 0.8.18;
+import "./IRealitio.sol";
+
+/**
+ *  @title IRealitioArbitrator
+ *  @dev Based on https://github.com/realitio/realitio-dapp/blob/1860548a51f52eba4930baad051f811e9f7adaee/docs/arbitrators.rst
+ */
+interface IRealitioArbitrator {
+    /** @dev Returns Realitio implementation instance.
+     */
+    function realitio() external view returns (IRealitio);
+
+    /** @dev Provides a string of json-encoded metadata. The following properties are scheduled for implementation in the Reality.eth dapp:
+        tos: A URI representing the location of a terms-of-service document for the arbitrator.
+        template_hashes: An array of hashes of templates supported by the arbitrator. If you have a numerical ID for a template registered with Reality.eth, you can look up this hash by calling the Reality.eth template_hashes() function.
+        Note that providing template hashes isn't required for Kleros.
+     */
+    function metadata() external view returns (string calldata);
+
+    /** @dev Returns arbitrators fee for arbitrating this question.
+     */
+    function getDisputeFee(bytes32 questionID) external view returns (uint256);
+}

--- a/contracts/src/interfaces/IRealitioArbitrator.sol
+++ b/contracts/src/interfaces/IRealitioArbitrator.sol
@@ -8,7 +8,7 @@
  *  @deployments: []
  */
 
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 import "./IRealitio.sol";
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adraffy/ens-normalize@npm:^1.10.1":
+  version: 1.11.0
+  resolution: "@adraffy/ens-normalize@npm:1.11.0"
+  checksum: abef75f21470ea43dd6071168e092d2d13e38067e349e76186c78838ae174a46c3e18ca50921d05bea6ec3203074147c9e271f8cb6531d1c2c0e146f3199ddcb
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0":
   version: 7.23.5
   resolution: "@babel/code-frame@npm:7.23.5"
@@ -1029,12 +1036,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kleros/kleros-v2-contracts@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@kleros/kleros-v2-contracts@npm:0.3.2"
+"@kleros/kleros-v2-contracts@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@kleros/kleros-v2-contracts@npm:0.7.0"
   dependencies:
-    "@kleros/vea-contracts": "npm:^0.3.2"
-  checksum: b97f3f3daca05b598217790d596b9cdbeace246f4dd1ee21b2b4d50a12624824859d8195eadc4e4514509667ea65da3723cb20bfed7ba6037d22fac6a4e306b2
+    "@kleros/vea-contracts": "npm:^0.4.0"
+    viem: "npm:^2.21.35"
+  checksum: 78c9762e45393eb3247755c6f9e39c8ec9020793918aca6e3fe7d970522eae91e16f9e81e653c3f05c26c375a4a5447889680cebdccedbf9a24345e74b289883
   languageName: node
   linkType: hard
 
@@ -1042,7 +1050,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kleros/reality-v2-contracts@workspace:contracts"
   dependencies:
-    "@kleros/kleros-v2-contracts": "npm:^0.3.2"
+    "@kleros/kleros-v2-contracts": "npm:^0.7.0"
     "@kleros/reality-v2-eslint-config": "workspace:^"
     "@kleros/reality-v2-prettier-config": "workspace:^"
     "@kleros/reality-v2-tsconfig": "workspace:^"
@@ -1052,6 +1060,7 @@ __metadata:
     "@nomicfoundation/hardhat-network-helpers": "npm:^1.0.0"
     "@nomicfoundation/hardhat-verify": "npm:^2.0.0"
     "@nomiclabs/hardhat-solhint": "npm:^3.0.1"
+    "@openzeppelin/contracts": "npm:^5.2.0"
     "@typechain/ethers-v6": "npm:^0.5.0"
     "@typechain/hardhat": "npm:^9.1.0"
     "@types/chai": "npm:^4.2.0"
@@ -1118,12 +1127,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kleros/vea-contracts@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@kleros/vea-contracts@npm:0.3.2"
-  dependencies:
-    "@openzeppelin/contracts": "npm:^4.8.3"
-  checksum: c91655c100f6623e230e5b7c1cb4308e9e382edfac5a63d2147a4a4ca83569418ca5f3e32a237a97c9668363cc2ce5e8a7d7133c9db7007e459a44e72ca37a2d
+"@kleros/vea-contracts@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@kleros/vea-contracts@npm:0.4.0"
+  checksum: 6e60eddf4f0bc9e687ddb83d634d800c75dc6bdd41be9f8904876f977dce2f661e183c4b3fc19d773d61b4b1d94fd4639c63d355d30e91f16f42d931a46dcbd5
   languageName: node
   linkType: hard
 
@@ -1223,6 +1230,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:1.7.0, @noble/curves@npm:~1.7.0":
+  version: 1.7.0
+  resolution: "@noble/curves@npm:1.7.0"
+  dependencies:
+    "@noble/hashes": "npm:1.6.0"
+  checksum: 2a11ef4895907d0b241bd3b72f9e6ebe56f0e705949bfd5efe003f25233549f620d287550df2d24ad56a1f953b82ec5f7cf4bd7cb78b1b2e76eb6dd516d44cf8
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:^1.6.0, @noble/curves@npm:~1.8.0":
+  version: 1.8.0
+  resolution: "@noble/curves@npm:1.8.0"
+  dependencies:
+    "@noble/hashes": "npm:1.7.0"
+  checksum: c54ce84cf54b8bda1a37a10dfae2e49e5b6cdf5dd98b399efa8b8a80a286b3f8f27bde53202cb308353bfd98719938991a78bed6e43f81f13b17f8181b7b82eb
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:1.2.0, @noble/hashes@npm:~1.2.0":
   version: 1.2.0
   resolution: "@noble/hashes@npm:1.2.0"
@@ -1241,6 +1266,27 @@ __metadata:
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 1025ddde4d24630e95c0818e63d2d54ee131b980fe113312d17ed7468bc18f54486ac86c907685759f8a7e13c2f9b9e83ec7b67d1cc20836f36b5e4a65bb102d
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@noble/hashes@npm:1.6.0"
+  checksum: b44b043b02adbecd33596adeed97d9f9864c24a2410f7ac3b847986c2ecf1f6f0df76024b3f1b14d6ea954932960d88898fe551fb9d39844a8b870e9f9044ea1
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.6.1, @noble/hashes@npm:~1.6.0":
+  version: 1.6.1
+  resolution: "@noble/hashes@npm:1.6.1"
+  checksum: 74d9ad7b1437a22ba3b877584add3367587fbf818113152f293025d20d425aa74c191d18d434797312f2270458bc9ab3241c34d14ec6115fb16438b3248f631f
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.7.0, @noble/hashes@npm:^1.5.0, @noble/hashes@npm:~1.7.0":
+  version: 1.7.0
+  resolution: "@noble/hashes@npm:1.7.0"
+  checksum: ab038a816c8c9bb986e92797e3d9c5a5b37c020e0c3edc55bcae5061dbdd457f1f0a22787f83f4787c17415ba0282a20a1e455d36ed0cdcace4ce21ef1869f60
   languageName: node
   linkType: hard
 
@@ -1657,10 +1703,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:^4.8.3":
-  version: 4.9.5
-  resolution: "@openzeppelin/contracts@npm:4.9.5"
-  checksum: f221d91a7dd96f9187aa832f8a160d673feb2904711bd210fab56ccfd8b8351b8150b4f0bd247701f7d4adddceba83943c049c6da11d126e07164b9abff767e0
+"@openzeppelin/contracts@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@openzeppelin/contracts@npm:5.2.0"
+  checksum: d77e1bdfca6fa1c40b5a32bb92220ec633ef86cc0bf43a011ad218c26c9e763c70ace3fc1e148a0462394a3aed8c5d7445935ebfeb146ba1454abec66625e420
   languageName: node
   linkType: hard
 
@@ -1675,6 +1721,13 @@ __metadata:
   version: 1.1.5
   resolution: "@scure/base@npm:1.1.5"
   checksum: 543fa9991c6378b6a0d5ab7f1e27b30bb9c1e860d3ac81119b4213cfdf0ad7b61be004e06506e89de7ce0cec9391c17f5c082bb34c3b617a2ee6a04129f52481
+  languageName: node
+  linkType: hard
+
+"@scure/base@npm:~1.2.1":
+  version: 1.2.1
+  resolution: "@scure/base@npm:1.2.1"
+  checksum: f7bdd17618ccae7a74c8cbe410a235e4adbe54aa8afe4e2fb1294338aa92f6fd04b1f1f5dea60552f638b5f5e3e74902b7baf59d3954e5e42c0a36c6baa2ebe0
   languageName: node
   linkType: hard
 
@@ -1711,6 +1764,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scure/bip32@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@scure/bip32@npm:1.6.0"
+  dependencies:
+    "@noble/curves": "npm:~1.7.0"
+    "@noble/hashes": "npm:~1.6.0"
+    "@scure/base": "npm:~1.2.1"
+  checksum: 2efb81ed9a7b8d5d35233e10abebc114544a3783a2a32b9fb60e1e9a67965b272c9d17910e1649083b69c8ceb80241b05b59dbeb7a5b18ea34e497aed3f16709
+  languageName: node
+  linkType: hard
+
+"@scure/bip32@npm:^1.5.0":
+  version: 1.6.1
+  resolution: "@scure/bip32@npm:1.6.1"
+  dependencies:
+    "@noble/curves": "npm:~1.8.0"
+    "@noble/hashes": "npm:~1.7.0"
+    "@scure/base": "npm:~1.2.1"
+  checksum: 967be60ab99dad33e44f0813d194d2eccffc0c5877e93fa01bd9d787b15210b383a98114aafacb704e36e58a90075a3eb51a78983914fadaed3bf4469b384064
+  languageName: node
+  linkType: hard
+
 "@scure/bip39@npm:1.1.1":
   version: 1.1.1
   resolution: "@scure/bip39@npm:1.1.1"
@@ -1738,6 +1813,26 @@ __metadata:
     "@noble/hashes": "npm:~1.3.2"
     "@scure/base": "npm:~1.1.4"
   checksum: f71aceda10a7937bf3779fd2b4c4156c95ec9813269470ddca464cb8ab610d2451b173037f4b1e6dac45414e406e7adc7b5814c51279f4474d5d38140bbee542
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@scure/bip39@npm:1.5.0"
+  dependencies:
+    "@noble/hashes": "npm:~1.6.0"
+    "@scure/base": "npm:~1.2.1"
+  checksum: b795ee31ac4c10603bf3b726cc0e5cf43834a68f05a535e0baf2162772bac100de470b4c6cf7ddbecb95d7a3fb82b8a959badced406c329ab696cd89104194bc
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:^1.4.0":
+  version: 1.5.1
+  resolution: "@scure/bip39@npm:1.5.1"
+  dependencies:
+    "@noble/hashes": "npm:~1.7.0"
+    "@scure/base": "npm:~1.2.1"
+  checksum: a7ba42169704173b687421a0f79e94d645d3954d4f6142b2edbb8466964ac8c7260337cfaab42f0372843da49595019bb1990a323ac6a7b6980b4d7c45924ddf
   languageName: node
   linkType: hard
 
@@ -2604,6 +2699,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abitype@npm:1.0.7":
+  version: 1.0.7
+  resolution: "abitype@npm:1.0.7"
+  peerDependencies:
+    typescript: ">=5.0.4"
+    zod: ^3 >=3.22.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+    zod:
+      optional: true
+  checksum: 6c2c3390a2f90186bf0df73f20cf257dfd9b62d1eb266de6ddf362030dcbd79cd113b4110e52f7802d7b042ea8fdb7ee2f113751b883787c2d9589d56fb4273b
+  languageName: node
+  linkType: hard
+
 "abitype@npm:^0.10.3":
   version: 0.10.3
   resolution: "abitype@npm:0.10.3"
@@ -2616,6 +2726,21 @@ __metadata:
     zod:
       optional: true
   checksum: 6eefcd8a63e2ecfaa9089125734d4542e8094160b43b38469eba3dfece167947ef8754c895be1a6b312088012fdc1740f7e338918e7ec7775a62807daec33ef5
+  languageName: node
+  linkType: hard
+
+"abitype@npm:^1.0.6":
+  version: 1.0.8
+  resolution: "abitype@npm:1.0.8"
+  peerDependencies:
+    typescript: ">=5.0.4"
+    zod: ^3 >=3.22.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+    zod:
+      optional: true
+  checksum: 878e74fbac6a971953649b6216950437aa5834a604e9fa833a5b275a6967cff59857c7e43594ae906387d2fb7cad9370138dec4298eb8814815a3ffb6365902c
   languageName: node
   linkType: hard
 
@@ -5461,7 +5586,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^5.0.1":
+"eventemitter3@npm:5.0.1, eventemitter3@npm:^5.0.1":
   version: 5.0.1
   resolution: "eventemitter3@npm:5.0.1"
   checksum: ac6423ec31124629c84c7077eed1e6987f6d66c31cf43c6fcbf6c87791d56317ce808d9ead483652436df171b526fc7220eccdc9f3225df334e81582c3cf7dd5
@@ -7244,6 +7369,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isows@npm:1.0.6":
+  version: 1.0.6
+  resolution: "isows@npm:1.0.6"
+  peerDependencies:
+    ws: "*"
+  checksum: ab9e85b50bcc3d70aa5ec875aa2746c5daf9321cb376ed4e5434d3c2643c5d62b1f466d93a05cd2ad0ead5297224922748c31707cb4fbd68f5d05d0479dce99c
+  languageName: node
+  linkType: hard
+
 "jackspeak@npm:^2.3.5":
   version: 2.3.6
   resolution: "jackspeak@npm:2.3.6"
@@ -8640,6 +8774,26 @@ __metadata:
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
   checksum: 5666560f7b9f10182548bf7013883265be33620b1c1b4a4d405c25be2636f970c5488ff3e6c48de75b55d02bde037249fe5dbfbb4c0fb7714953d56aed062e6d
+  languageName: node
+  linkType: hard
+
+"ox@npm:0.6.5":
+  version: 0.6.5
+  resolution: "ox@npm:0.6.5"
+  dependencies:
+    "@adraffy/ens-normalize": "npm:^1.10.1"
+    "@noble/curves": "npm:^1.6.0"
+    "@noble/hashes": "npm:^1.5.0"
+    "@scure/bip32": "npm:^1.5.0"
+    "@scure/bip39": "npm:^1.4.0"
+    abitype: "npm:^1.0.6"
+    eventemitter3: "npm:5.0.1"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 60ca483cd8ae98335857ed971febdc524e79b42f7db610893c71566e4b6d0bbd9ff009a762dde29762801fd4ff0c4d5d375213b95a4eced676eb60b681131fa9
   languageName: node
   linkType: hard
 
@@ -11351,6 +11505,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"viem@npm:^2.21.35":
+  version: 2.22.9
+  resolution: "viem@npm:2.22.9"
+  dependencies:
+    "@noble/curves": "npm:1.7.0"
+    "@noble/hashes": "npm:1.6.1"
+    "@scure/bip32": "npm:1.6.0"
+    "@scure/bip39": "npm:1.5.0"
+    abitype: "npm:1.0.7"
+    isows: "npm:1.0.6"
+    ox: "npm:0.6.5"
+    ws: "npm:8.18.0"
+  peerDependencies:
+    typescript: ">=5.0.4"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 29ddd53851a66946393e0763f87849e467530d8f8bd0e270bcd1f1d5f5c718a7c0ae28a159fbfc0eb38dda6c1ce7cc1c31cf5cc81671140888cbcbbd011c92b8
+  languageName: node
+  linkType: hard
+
 "vue-hot-reload-api@npm:^2.3.0":
   version: 2.3.4
   resolution: "vue-hot-reload-api@npm:2.3.4"
@@ -11683,6 +11858,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 1769532b6fdab9ff659f0b17810e7501831d34ecca23fd179ee64091dd93a51f42c59f6c7bb4c7a384b6c229aca8076fb312aa35626257c18081511ef62a161d
+  languageName: node
+  linkType: hard
+
+"ws@npm:8.18.0":
+  version: 8.18.0
+  resolution: "ws@npm:8.18.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 70dfe53f23ff4368d46e4c0b1d4ca734db2c4149c6f68bc62cb16fc21f753c47b35fcc6e582f3bdfba0eaeb1c488cddab3c2255755a5c3eecb251431e42b3ff6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- The main proxy contract wasn't actually modified but replaced with the contract from local repo.
- Governance functions are removed since we never use governance in RealitioProxies.
- Metaevidence currently uses the old pattern with template registry as a placeholder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `RealitioProxyV2` contract with enhanced arbitration functionalities.
  - Added new interfaces `IRealitio` and `IRealitioArbitrator` to facilitate external interactions.
  - Implemented new functions for governors to change arbitration parameters and template registries.
  - Added a `requestArbitration` function for submitting arbitration requests.
  - Introduced a `reportAnswer` function for reporting answers after rulings.

- **Improvements**
  - Updated constructor parameters and initialization for better configuration.
  - Simplified dispute handling by introducing new structs and enums.
  - Enhanced flexibility of dispute templates with dynamic content insertion.

- **Bug Fixes**
  - Enhanced error handling to provide clearer feedback for incorrect operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->